### PR TITLE
Split File/Directory handler functions to ease reuse

### DIFF
--- a/wptserve/handlers.py
+++ b/wptserve/handlers.py
@@ -30,7 +30,9 @@ def guess_content_type(path):
 class DirectoryHandler(object):
     def __call__(self, request, response):
         path = request.filesystem_path
-
+        return self.serve_directory(path, request, response)
+        
+    def serve_directory(self, path, request, response):
         assert os.path.isdir(path)
 
         response.headers = [("Content-Type", "text/html")]
@@ -69,9 +71,11 @@ directory_handler = DirectoryHandler()
 class FileHandler(object):
     def __call__(self, request, response):
         path = request.filesystem_path
+        return self.serve_file(path, request, response)
 
+    def serve_file(self, path, request, response):
         if os.path.isdir(path):
-            return directory_handler(request, response)
+            return directory_handler.serve_directory(path, request, response)
         try:
             #This is probably racy with some other process trying to change the file
             file_size = os.stat(path).st_size

--- a/wptserve/router.py
+++ b/wptserve/router.py
@@ -136,7 +136,7 @@ class Router(object):
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))
-            print self.routes[-1][1].pattern
+            logger.info(self.routes[-1][1].pattern)
 
     def get_handler(self, request):
         """Get a handler for a request or None if there is no handler.


### PR DESCRIPTION
Split helps in reusing those handlers for alias based requests.
This helps in webkit where the /resources/* requests may need to be mapped to a directory that is not in the server doc_root.

Minor change in router.py to improve the logging 