### PR TITLE
Include README.md for source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
Since setup.py reads README.md on installation, this must be included in
the source distribution for installation to succeed.
