### PR TITLE
Missing media types and change of type for XML

### DIFF
--- a/wptserve/constants.py
+++ b/wptserve/constants.py
@@ -2,10 +2,10 @@ import utils
 
 content_types = utils.invert_dict({"text/html": ["htm", "html"],
                                    "application/xhtml+xml": ["xht", "xhtm", "xhtml"],
+                                   "application/xml": ["xml"],
                                    "text/javascript": ["js"],
                                    "text/css": ["css"],
                                    "text/plain": ["txt", "md"],
-                                   "text/xml": ["xml"],
                                    "image/svg+xml": ["svg"],
                                    "image/gif": ["gif"],
                                    "image/jpeg": ["jpg", "jpeg"],


### PR DESCRIPTION
The XML change matches what the DOM test suite expects. We could also change the tests, but I suspect that this matches the configuration we had previously.
