### PR TITLE
Fixed Request.url to take the Host HTTP header into account with HTTP/1.1

### DIFF
--- a/wptserve/request.py
+++ b/wptserve/request.py
@@ -244,9 +244,7 @@ class Request(object):
             host = request_handler.server.server_address[0]
         else:
             if ":" in host:
-                host_header = host.split(":")
-                host = host_header[0]
-                port = host_header[1]
+                host, port = host.split(":", 1)
 
         self.request_path = request_handler.path
 


### PR DESCRIPTION
This will fix the result of the test "Request URL test" in
   http://w3c-test.org/XMLHttpRequest/open-url-worker-origin.htm
