### PR TITLE
Add JSON and XPI content type support (#30)

### DIFF
--- a/wptserve/constants.py
+++ b/wptserve/constants.py
@@ -1,8 +1,10 @@
 import utils
 
 content_types = utils.invert_dict({"text/html": ["htm", "html"],
+                                   "application/json": ["json"],
                                    "application/xhtml+xml": ["xht", "xhtm", "xhtml"],
                                    "application/xml": ["xml"],
+                                   "application/x-xpinstall": ["xpi"],
                                    "text/javascript": ["js"],
                                    "text/css": ["css"],
                                    "text/plain": ["txt", "md"],


### PR DESCRIPTION
PR for #30
This allows identification for Mozilla XPI files.
