### PR TITLE
Add the 'Last-Modified' header to the default file handler

### DIFF
--- a/wptserve/handlers.py
+++ b/wptserve/handlers.py
@@ -76,6 +76,8 @@ class FileHandler(object):
         try:
             #This is probably racy with some other process trying to change the file
             file_size = os.stat(path).st_size
+            last_modified = response.writer._handler.date_time_string(os.stat(path).st_mtime)
+            response.headers.set("Last-Modified", last_modified)
             response.headers.update(self.get_headers(path))
             if "Range" in request.headers:
                 try:


### PR DESCRIPTION
The default file handler is missing the`Last-Modified` header, this doesn't allow the browser to cache any resource.

Found this problem with a mozmill/mutt test that was checking "http-on-examine-response" vs "http-on-examine-cached-response" observers, and in the case of wptserve we never got any resource from the local cache.

This PR fixes the problem by setting this header.

@jgraham please review when you have time. Thanks
