### PR TITLE
adding Basic Auth Handler

### DIFF
--- a/wptserve/handlers.py
+++ b/wptserve/handlers.py
@@ -306,7 +306,7 @@ class BasicAuthHandler(object):
                 return response
             return self.handler(request, response)
 
-basic_auth_handler = BasicAuthHandler()
+basic_auth_handler = BasicAuthHandler(file_handler, None, None)
 
 class ErrorHandler(object):
     def __init__(self, status):


### PR DESCRIPTION
I'd like to have web-platform-tests/webdriver start using this server instead:

https://github.com/lukeis/web-platform-tests/commit/0128116fdc00283ff3e4f31d4865adeb820dfb29

this change was required to have a way to configure how to handle http auth requests. Let me know if there's a more pythonic way to deal with the credentials.
