### PR TITLE
Gracefully fail to empty string if KeyError in template sub processing

### DIFF
--- a/wptserve/pipes.py
+++ b/wptserve/pipes.py
@@ -312,8 +312,8 @@ class FirstWrapper(object):
     def __getitem__(self, key):
         try:
           return self.params.first(key)
-	except KeyError:
-	  return ""
+        except KeyError:
+          return ""
 
 
 @pipe()


### PR DESCRIPTION
Parameters in substitution processing may be optional, but current code causes a 500 error with a KeyError if, e.g. a GET value is unset.  Fail gracefully to the empty string instead.
