### PR TITLE
Add support for configurable logging.

### DIFF
--- a/wptserve/handlers.py
+++ b/wptserve/handlers.py
@@ -12,8 +12,6 @@ from ranges import RangeParser
 from response import MultipartContent
 from utils import HTTPException
 
-logger = logging.getLogger("wptserve")
-
 __all__ = ["file_handler", "python_script_handler",
            "FunctionHandler", "handler", "json_handler",
            "as_is_handler", "ErrorHandler"]

--- a/wptserve/logger.py
+++ b/wptserve/logger.py
@@ -1,0 +1,29 @@
+class NoOpLogger(object):
+    def critical(self, msg):
+        pass
+
+    def error(self, msg):
+        pass
+
+    def info(self, msg):
+        pass
+
+    def warning(self, msg):
+        pass
+
+    def debug(self, msg):
+        pass
+
+logger = NoOpLogger()
+_set_logger = False
+
+def set_logger(new_logger):
+    global _set_logger
+    if _set_logger:
+        raise Exception("Logger must be set at most once")
+    global logger
+    logger = new_logger
+    _set_logger = True
+
+def get_logger():
+    return logger

--- a/wptserve/pipes.py
+++ b/wptserve/pipes.py
@@ -7,8 +7,6 @@ import types
 import uuid
 from cStringIO import StringIO
 
-logger = logging.getLogger("wptserve")
-
 
 def resolve_content(response):
     rv = "".join(item for item in response.iter_content())

--- a/wptserve/request.py
+++ b/wptserve/request.py
@@ -10,7 +10,6 @@ import urlparse
 import stash
 from utils import HTTPException
 
-logger = logging.getLogger("wptserve")
 missing = object()
 
 

--- a/wptserve/response.py
+++ b/wptserve/response.py
@@ -8,10 +8,9 @@ import uuid
 import socket
 
 from constants import response_codes
+from logger import get_logger
 
-logger = logging.getLogger("wptserve")
 missing = object()
-
 
 class Response(object):
     """Object representing the response to a HTTP request
@@ -76,6 +75,8 @@ class Response(object):
         self._status = (200, None)
         self.headers = ResponseHeaders()
         self.content = []
+
+        self.logger = get_logger()
 
     @property
     def status(self):
@@ -213,7 +214,7 @@ class Response(object):
                         ("Content-Length", len(data))]
         self.content = data
         if code == 500:
-            logger.error(message)
+            self.logger.error(message)
 
 
 class MultipartContent(object):

--- a/wptserve/router.py
+++ b/wptserve/router.py
@@ -3,8 +3,7 @@ import logging
 import re
 import types
 
-logger = logging.getLogger("wptserve")
-logger.setLevel(logging.DEBUG)
+from logger import get_logger
 
 any_method = object()
 
@@ -99,6 +98,7 @@ class Router(object):
     def __init__(self, doc_root, routes):
         self.doc_root = doc_root
         self.routes = []
+        self.logger = get_logger()
         for route in reversed(routes):
             self.register(*route)
 
@@ -140,7 +140,7 @@ class Router(object):
             methods = [methods]
         for method in methods:
             self.routes.append((method, compile_path_match(path), handler))
-            logger.debug("Route pattern: %s" % self.routes[-1][1].pattern)
+            self.logger.debug("Route pattern: %s" % self.routes[-1][1].pattern)
 
     def get_handler(self, request):
         """Get a handler for a request or None if there is no handler.
@@ -158,7 +158,7 @@ class Router(object):
                         name = handler.__name__
                     else:
                         name = handler.__class__.__name__
-                    logger.debug("Found handler %s" % name)
+                    self.logger.debug("Found handler %s" % name)
 
                     match_parts = m.groupdict().copy()
                     if len(match_parts) < len(m.groups()):

--- a/wptserve/server.py
+++ b/wptserve/server.py
@@ -12,15 +12,13 @@ import traceback
 import types
 import urlparse
 
+import routes as default_routes
+from logger import get_logger
 from request import Server, Request
 from response import Response
 from router import Router
-import routes as default_routes
 from utils import HTTPException
 
-
-logger = logging.getLogger("wptserve")
-logger.setLevel(logging.DEBUG)
 
 """HTTP server designed for testing purposes.
 
@@ -67,6 +65,7 @@ class RequestRewriter(object):
         self.rules = {}
         for rule in reversed(rules):
             self.register(*rule)
+        self.logger = get_logger()
 
     def register(self, methods, input_path, output_path):
         """Register a rewrite rule.
@@ -95,7 +94,7 @@ class RequestRewriter(object):
         if split_url.path in self.rules:
             methods, destination = self.rules[split_url.path]
             if "*" in methods or request_handler.command in methods:
-                logger.debug("Rewriting request path %s to %s" %
+                self.logger.debug("Rewriting request path %s to %s" %
                              (request_handler.path, destination))
                 new_url = list(split_url)
                 new_url[2] = destination
@@ -143,6 +142,7 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         self.rewriter = rewriter
 
         self.scheme = "https" if use_ssl else "http"
+        self.logger = get_logger()
 
         if bind_hostname:
             hostname_port = server_address
@@ -155,7 +155,7 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
         if config is not None:
             Server.config = config
         else:
-            logger.debug("Using default configuration")
+            self.logger.debug("Using default configuration")
             Server.config = {"host": server_address[0],
                              "domains": {"": server_address[0]},
                              "ports": {"http": [self.server_address[1]]}}
@@ -177,7 +177,7 @@ class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
              error.errno in self.acceptable_errors)):
             pass  # remote hang up before the result is sent
         else:
-            logger.error(traceback.format_exc())
+            self.logger.error(traceback.format_exc())
 
 
 class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
@@ -187,6 +187,7 @@ class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     def handle_one_request(self):
         response = None
+        logger = get_logger()
         try:
             self.close_connection = False
             request_line_is_valid = self.get_request_line()
@@ -225,8 +226,11 @@ class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                         err = []
                         err.append(traceback.format_exc())
                     response.set_error(500, "\n".join(err))
-            logger.info("%i %s %s (%s) %i" % (response.status[0], request.method,
-                                         request.request_path, request.headers.get('Referer'), request.raw_input.length))
+            logger.debug("%i %s %s (%s) %i" % (response.status[0],
+                                               request.method,
+                                               request.request_path,
+                                               request.headers.get('Referer'),
+                                               request.raw_input.length))
 
             if not response.writer.content_written:
                 response.write()
@@ -334,6 +338,7 @@ class WebTestHttpd(object):
         self.rewriter = rewriter_cls(rewrites if rewrites is not None else [])
 
         self.use_ssl = use_ssl
+        self.logger = get_logger()
 
         if server_cls is None:
             server_cls = WebTestServer
@@ -357,7 +362,7 @@ class WebTestHttpd(object):
 
             _host, self.port = self.httpd.socket.getsockname()
         except Exception:
-            logger.error('Init failed! You may need to modify your hosts file. Refer to README.md.');
+            self.logger.error('Init failed! You may need to modify your hosts file. Refer to README.md.');
             raise
 
     def start(self, block=False):
@@ -365,7 +370,7 @@ class WebTestHttpd(object):
 
         :param block: True to run the server on the current thread, blocking,
                       False to run on a separate thread."""
-        logger.info("Starting http server on %s:%s" % (self.host, self.port))
+        self.logger.info("Starting http server on %s:%s" % (self.host, self.port))
         self.started = True
         if block:
             self.httpd.serve_forever()
@@ -386,7 +391,7 @@ class WebTestHttpd(object):
                 self.httpd.server_close()
                 self.server_thread.join()
                 self.server_thread = None
-                logger.info("Stopped http server on %s:%s" % (self.host, self.port))
+                self.logger.info("Stopped http server on %s:%s" % (self.host, self.port))
             except AttributeError:
                 pass
             self.started = False


### PR DESCRIPTION
This makes the wptserve logging pluggable so that python logging can be used
for the normal serve.py case and mozlog's structured logging can be used
when running from wptrunner for compatibility with the rest of the logs there.
