### PR TITLE
Increase TCP connection backlog

### DIFF
--- a/wptserve/server.py
+++ b/wptserve/server.py
@@ -105,6 +105,7 @@ class RequestRewriter(object):
 class WebTestServer(ThreadingMixIn, BaseHTTPServer.HTTPServer):
     allow_reuse_address = True
     acceptable_errors = (errno.EPIPE, errno.ECONNABORTED)
+    request_queue_size = 2000
 
     # Ensure that we don't hang on shutdown waiting for requests
     daemon_threads = True


### PR DESCRIPTION
The default is 5. This causes problems with tests that attempt to initiate multiple connections simultaneously, or when running multiple tests in parallel.
