### PR TITLE
Stash: Basic support for shared data between processes.

### DIFF
--- a/wptserve/request.py
+++ b/wptserve/request.py
@@ -1,6 +1,7 @@
 import base64
 import cgi
 import Cookie
+import os
 import StringIO
 import tempfile
 import urlparse
@@ -27,7 +28,9 @@ class Server(object):
     config = None
 
     def __init__(self, request):
-        self.stash = stash.Stash(request.url_parts.path)
+        host, port, authkey = stash.load_env_config()
+        address = (host, port)
+        self.stash = stash.Stash(request.url_parts.path, address, authkey)
 
 
 class InputFile(object):

--- a/wptserve/stash.py
+++ b/wptserve/stash.py
@@ -1,17 +1,51 @@
 import uuid
+from multiprocessing import Process
+from multiprocessing.managers import SyncManager, DictProxy
+import os
+import json
+
+
+WPT_STASH_CONFIG = "WPT_STASH_CONFIG"
+
+def load_env_config():
+    return json.loads(os.environ[WPT_STASH_CONFIG])
+
+def store_env_config(config):
+    os.environ[WPT_STASH_CONFIG] = json.dumps(config)
+
+def start_server(address=None, authkey=None):
+    shared_data = {}
+    class DictManager(SyncManager):
+        pass
+
+    DictManager.register("get_dict",
+                         callable=lambda:shared_data,
+                         proxytype=DictProxy)
+    manager = DictManager(address, authkey)
+    server = manager.get_server()
+    server_process = Process(target=server.serve_forever)
+    server_process.start()
+
+    return (server_process, manager._address, manager._authkey)
+
 
 #TODO: Consider expiring values after some fixed time for long-running
 #servers
 
+# TODO(kristijanburnik): Provide shared Stash support for WebSockets.
 
 class Stash(object):
-    """Key-value store for persisting data across HTTP requests.
+    """Key-value store for persisting data across HTTP/S requests.
 
-    This data store specifically designed for persisting data across
-    HTTP requests. It is entirely in-memory so data will not be
-    persisted across server restarts.
+    This data store is specifically designed for persisting data across
+    HTTP and HTTPS requests. The synchronization model is usually done by using
+    the SyncManager from the multiprocessing module.
 
-    This has several unusual properties. Keys are of the form (path,
+    Stash can be used interchangeably between HTTP and HTTPS requests as both
+    processes are accessing the same resource (e.g. a Manager.dict).
+    The WS and WSS servers are currently not supported.
+
+    The store has several unusual properties. Keys are of the form (path,
     uuid), where path is, by default, the path in the HTTP request and
     uuid is a unique id. In addition, the store is write-once, read-once,
     i.e. the value associated with a particular key cannot be changed once
@@ -19,66 +53,70 @@ class Stash(object):
     these properties make it difficult for data to accidentally leak
     between different resources or different requests for the same
     resource.
-
     """
 
-    data = {}
+    _proxy = None
 
-    def __init__(self, default_path):
+    def __init__(self, default_path, address=None, authkey=None):
         self.default_path = default_path
+        self.data = self._get_proxy(address, authkey)
+
+    def _get_proxy(self, address=None, authkey=None):
+        if address is None and authkey is None:
+            Stash._proxy = {}
+
+        if Stash._proxy is None:
+            class DictManager(SyncManager):
+                pass
+
+            DictManager.register("get_dict")
+            manager = DictManager(address, authkey)
+            manager.connect()
+            Stash._proxy = manager.get_dict()
+
+        return Stash._proxy
+
+    def _wrap_key(self, key, path):
+        if path is None:
+            path = self.default_path
+        # This key format is required to support using the path. Since the data
+        # passed into the stash can be a DictProxy which wouldn't detect changes
+        # when writing to a subdict.
+        return (str(path), str(uuid.UUID(key)))
 
     def put(self, key, value, path=None):
-        """Place a value in the stash.
+        """Place a value in the shared stash.
 
         :param key: A UUID to use as the data's key.
         :param value: The data to store. This can be any python object.
         :param path: The path that has access to read the data (by default
                      the current request path)"""
-        if path is None:
-            path = self.default_path
-        if path not in self.data:
-            self.data[path] = PathStash(path)
-
-        self.data[path][key] = value
+        if value is None:
+            raise ValueError("SharedStash value may not be set to None")
+        internal_key = self._wrap_key(key, path)
+        if internal_key in self.data:
+            raise StashError("Tried to overwrite existing shared stash value "
+                             "for key %s (old value was %s, new value is %s)" %
+                             (internal_key, self[str(internal_key)], value))
+        else:
+            self.data[internal_key] = value
 
     def take(self, key, path=None):
-        """Remove a value from the stash and return it.
+        """Remove a value from the shared stash and return it.
 
         :param key: A UUID to use as the data's key.
         :param path: The path that has access to read the data (by default
                      the current request path)"""
-        if path is None:
-            path = self.default_path
+        internal_key = self._wrap_key(key, path)
+        value = self.data.get(internal_key, None)
+        if not value is None:
+            try:
+                self.data.pop(internal_key)
+            except KeyError:
+                # Silently continue when pop error occurs.
+                pass
 
-        if path in self.data:
-            value = self.data[path][key]
-        else:
-            value = None
         return value
-
-
-class PathStash(dict):
-    def __init__(self, path):
-        self.path = path
-
-    def __setitem__(self, key, value):
-        key = uuid.UUID(key)
-        if value is None:
-            raise ValueError("Stash value may not be set to None")
-        if key in self:
-            raise StashError("Tried to overwrite existing stash value "
-                             "for path %s and key %s (old value was %s, new value is %s)" %
-                             (self.path, key, self[str(key)], value))
-        else:
-            dict.__setitem__(self, key, value)
-
-    def __getitem__(self, key):
-        key = uuid.UUID(key)
-        rv = dict.get(self, key, None)
-        if rv is not None:
-            del self[key]
-        return rv
-
 
 class StashError(Exception):
     pass


### PR DESCRIPTION
Proof of concept for a SharedStash.

SharedStash represents a wrapper for a dictionary shared between processes.
E.g. a Manager.dict object will represent a shared dictionary between a parent
and a child process. The processes could be the invoking main process and the
child processes running the HTTP, HTTPS, WS and WSS servers.

The behavior of SharedStash resembles Stash from a caller's perspective
when using put and take. However, direct access to data is discouraged as
the internal structure does not match the one used by Stash.

@jgraham, @mikewest 
