### PR TITLE
Implement 405 for unhandled non-GET requests.

### DIFF
--- a/wptserve/server.py
+++ b/wptserve/server.py
@@ -242,7 +242,13 @@ class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 time.sleep(latency / 1000.)
 
             if handler is None:
-                response.set_error(404)
+                if request.method in ["GET"]:
+                    # Assume no handler means path to a non-existing resource.
+                    response.set_error(404, "Not found")
+                else:
+                    # Using a non-GET method without a dedicated handler is
+                    # considered not allowed. E.g. if requesting files via POST.
+                    response.set_error(405, "Method not allowed")
             else:
                 try:
                     handler(request, response)


### PR DESCRIPTION
Respond with a `405 Method not allowed` for non-GET requests which don't match a handler.

The assumption is that a client is sending a POST/PUT/DELETE request for a resource which is otherwise available via GET, therefore respond with 405.

If a handler is not found and the GET method was used, we assume the resource does not exist (404).

@jgraham 
