### PR TITLE
Closing response file handle

### DIFF
--- a/wptserve/response.py
+++ b/wptserve/response.py
@@ -453,6 +453,7 @@ class ResponseWriter(object):
                 self._wfile.write(buf)
             except socket.error:
                 break
+        data.close()
 
     def encode(self, data):
         """Convert unicode to bytes according to response.encoding."""


### PR DESCRIPTION
As per https://bugs.webkit.org/show_bug.cgi?id=158137, WebKit mac bots sometimes hit "[Errno 24] Too many open files".
Closing explicitly response file handles may be helpful.