### PR TITLE
Deal with line ending issues; PEP 278

### DIFF
--- a/tests/functional/base.py
+++ b/tests/functional/base.py
@@ -56,6 +56,6 @@ class TestUsingServer(unittest.TestCase):
             req.add_data(body)
 
         if auth is not None:
-            req.add_header("Authorization", "Basic %s" % base64.encodestring('%s:%s' % auth))
+            req.add_header("Authorization", "Basic %s" % base64.b64encode('%s:%s' % auth))
 
         return urllib2.urlopen(req)

--- a/tests/functional/test_handlers.py
+++ b/tests/functional/test_handlers.py
@@ -12,7 +12,7 @@ class TestFileHandler(TestUsingServer):
         resp = self.request("/document.txt")
         self.assertEquals(200, resp.getcode())
         self.assertEquals("text/plain", resp.info()["Content-Type"])
-        self.assertEquals(open(os.path.join(doc_root, "document.txt")).read(), resp.read())
+        self.assertEquals(open(os.path.join(doc_root, "document.txt"), 'rb').read(), resp.read())
 
     def test_headers(self):
         resp = self.request("/with_headers.txt")
@@ -27,7 +27,7 @@ class TestFileHandler(TestUsingServer):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-19"})
         self.assertEquals(206, resp.getcode())
         data = resp.read()
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(10, len(data))
         self.assertEquals("bytes 10-19/%i" % len(expected), resp.info()['Content-Range'])
         self.assertEquals("10", resp.info()['Content-Length'])
@@ -37,7 +37,7 @@ class TestFileHandler(TestUsingServer):
         resp = self.request("/document.txt", headers={"Range":"bytes=10-"})
         self.assertEquals(206, resp.getcode())
         data = resp.read()
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(len(expected) - 10, len(data))
         self.assertEquals("bytes 10-%i/%i" % (len(expected) - 1, len(expected)), resp.info()['Content-Range'])
         self.assertEquals(expected[10:], data)
@@ -46,7 +46,7 @@ class TestFileHandler(TestUsingServer):
         resp = self.request("/document.txt", headers={"Range":"bytes=-10"})
         self.assertEquals(206, resp.getcode())
         data = resp.read()
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(10, len(data))
         self.assertEquals("bytes %i-%i/%i" % (len(expected) - 10,
                                               len(expected) - 1,
@@ -57,7 +57,7 @@ class TestFileHandler(TestUsingServer):
         resp = self.request("/document.txt", headers={"Range":"bytes=1-2,5-7,6-10"})
         self.assertEquals(206, resp.getcode())
         data = resp.read()
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertTrue(resp.info()["Content-Type"].startswith("multipart/byteranges; boundary="))
         boundary = resp.info()["Content-Type"].split("boundary=")[1]
         parts = data.split("--" + boundary)
@@ -76,7 +76,7 @@ class TestFileHandler(TestUsingServer):
             self.request("/document.txt", headers={"Range":"bytes=11-10"})
         self.assertEquals(cm.exception.code, 416)
 
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         with self.assertRaises(urllib2.HTTPError) as cm:
             self.request("/document.txt", headers={"Range":"bytes=%i-%i" % (len(expected), len(expected) + 10)})
         self.assertEquals(cm.exception.code, 416)

--- a/tests/functional/test_pipes.py
+++ b/tests/functional/test_pipes.py
@@ -37,34 +37,34 @@ class TestHeader(TestUsingServer):
 class TestSlice(TestUsingServer):
     def test_both_bounds(self):
         resp = self.request("/document.txt", query="pipe=slice(1,10)")
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(resp.read(), expected[1:10])
 
     def test_no_upper(self):
         resp = self.request("/document.txt", query="pipe=slice(1)")
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(resp.read(), expected[1:])
 
     def test_no_lower(self):
         resp = self.request("/document.txt", query="pipe=slice(null,10)")
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(resp.read(), expected[:10])
 
 class TestSub(TestUsingServer):
     def test_sub_config(self):
         resp = self.request("/sub.txt", query="pipe=sub")
-        expected = "localhost localhost %i\n" % self.server.port
-        self.assertEquals(resp.read(), expected)
+        expected = "localhost localhost %i" % self.server.port
+        self.assertEquals(resp.read().rstrip(), expected)
 
     def test_sub_headers(self):
         resp = self.request("/sub_headers.txt", query="pipe=sub", headers={"X-Test": "PASS"})
-        expected = "PASS\n"
-        self.assertEquals(resp.read(), expected)
+        expected = "PASS"
+        self.assertEquals(resp.read().rstrip(), expected)
 
     def test_sub_params(self):
         resp = self.request("/sub_params.txt", query="test=PASS&pipe=sub")
-        expected = "PASS\n"
-        self.assertEquals(resp.read(), expected)
+        expected = "PASS"
+        self.assertEquals(resp.read().rstrip(), expected)
 
 class TestTrickle(TestUsingServer):
     def test_trickle(self):
@@ -72,7 +72,7 @@ class TestTrickle(TestUsingServer):
         t0 = time.time()
         resp = self.request("/document.txt", query="pipe=trickle(1:d2:5:d1:r2)")
         t1 = time.time()
-        expected = open(os.path.join(doc_root, "document.txt")).read()
+        expected = open(os.path.join(doc_root, "document.txt"), 'rb').read()
         self.assertEquals(resp.read(), expected)
         self.assertGreater(6, t1-t0)
 


### PR DESCRIPTION
Tests now match wptserve use of open()

Also switched base64.encodestring (which adds \n) to
base64.b64encode which creates a valid header.


Mostly, this gets tests running on Windows (which I use...).

Thanks!
:tophat: 