### PR TITLE
Fix RequestHeaders to proper concat repeats

### DIFF
--- a/wptserve/request.py
+++ b/wptserve/request.py
@@ -348,12 +348,22 @@ class Request(object):
 class RequestHeaders(dict):
     """Dictionary-like API for accessing request headers."""
     def __init__(self, items):
-        for key, value in zip(items.keys(), items.values()):
-            key = key.lower()
-            if key in self:
-                self[key].append(value)
+        for header in items.keys():
+            key = header.lower()
+            # if there are other headers with this name, we need them
+            values = items.getallmatchingheaders(header)
+            if len(values) > 1:
+                # collect the multiple variations of the current header
+                multiples = []
+                # loop through the values from getallmatchingheaders
+                for value in values:
+                    # split the raw header on the first `:`
+                    # and add that to our list
+                    multiples.append(value.split(':', 1)[1].strip())
+                dict.__setitem__(self, key, multiples)
             else:
-                dict.__setitem__(self, key, [value])
+                # adds the last header with this name
+                dict.__setitem__(self, key, [items[header]])
 
     def __getitem__(self, key):
         """Get all headers of a certain (case-insensitive) name. If there is


### PR DESCRIPTION
Previously RequestHeaders only provided the last instance of a repeated header.

Sadly, writing a unit test for this has proved...daunting. Python libraries from urllib's 1-3, Requests, and even httplib do not allow one to construct a header sequence like the one below (from the [Web Annotation Protocol spec](https://rawgit.com/w3c/web-annotation/protocol-qs/protocol/wd/index.html#h-representations-without-annotations)):

``` http
GET /annotations/ HTTP/1.1
Host: example.org
Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"
Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"
Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"
```

Most of these libraries use a dictionary style interface, and when given multiple values for a single header, they send them as a comma separated list (as they should! re: RFC 7230, RFC 2616, etc). However, because of that writing a test that would match the exact request seen above is...non-trivial (with the most likely suggestions being to "just use the sockets library")--which goes beyond what I care to attempt (or have time to...) in order to prove that this works. :confounded: 

So. Instead, here's one loverly curl line for your copy/paste enjoyment:

``` bash
curl http://localhost:8080 \
-H 'Accept: application/ld+json; profile="http://www.w3.org/ns/anno.jsonld"' \
-H 'Prefer: return=representation;include="http://www.w3.org/ns/ldp#PreferMinimalContainer"' \
-H 'Prefer: return=representation;include="http://www.w3.org/ns/oa#PreferContainedIRIs"'
```

And a simple server to test it against:

``` python
import json

import wptserve

port = 8080
doc_root = './docroot/'

@wptserve.handlers.handler
def multi(request, response):
    return json.dumps(request.headers, indent=4)

routes = [
    ("GET", "*", multi)
]

print 'http://localhost:{0}/'.format(port)

httpd = wptserve.server.WebTestHttpd(port=port, doc_root=doc_root,
                                     routes=routes)
httpd.start(block=True)
```

Which, if run against each other, should result in this JSON:

``` json
{
    "host": "localhost:8080",
    "prefer": "return=representation;include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\", return=representation;include=\"http://www.w3.org/ns/ldp#PreferMinimalContainer\"",
    "accept": "application/ld+json; profile=\"http://www.w3.org/ns/anno.jsonld\"",
    "user-agent": "curl/7.41.0"
}
```

Cheers.
:tophat:

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptserve/87)

<!-- Reviewable:end -->
