### PR TITLE
Add support for optional default headers

### DIFF
--- a/wptserve/handlers.py
+++ b/wptserve/handlers.py
@@ -63,7 +63,7 @@ class DirectoryHandler(object):
         if not os.path.isdir(path):
             raise HTTPException(404, "%s is not a directory" % path)
 
-        response.headers = [("Content-Type", "text/html")]
+        response.headers.set("Content-Type", "text/html")
         response.content = """<!doctype html>
 <meta name="viewport" content="width=device-width">
 <title>Directory listing for %(path)s</title>


### PR DESCRIPTION
This change adds support for default headers. 

``` python
import wptserve

config = {
    "host": "localhost",
    "domains": {
        "": "localhost"
    },
    "ports": {
        "http": [8000]
    },
    # new!
    "default_headers": [
        ["Cache-Control", "no-cache, no-store"]
    ]
}

httpd = wptserve.WebTestHttpd(config=config)
httpd.start(block=True)
```

Default headers are useful in setting the default cache policy for wptserve when serving test files for Internet Explorer and Edge in dev and test environments, so that test files are not inadvertently cached between runs. This prevents "F5-refresh" headaches when a developer makes changes to the tests locally, and prevents leftover state on shared machines (which may need to run multiple versions of the tests) from affecting subsequent test runs.

This feature is meant to be _complementary_ to specifying per-resource headers in `.header` files, header pipes, Python scripts, and so forth. Any of these explicit mechanisms will override the default headers.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptserve/88)

<!-- Reviewable:end -->
