### PR TITLE
Support handlers altering the set of files that appear in a directory listing.

### DIFF
--- a/wptserve/request.py
+++ b/wptserve/request.py
@@ -237,9 +237,11 @@ class Request(object):
     .. attribute:: server
 
     Server object containing information about the server environment.
+
     """
 
     def __init__(self, request_handler):
+        self.router = request_handler.server.router
         self.doc_root = request_handler.server.router.doc_root
         self.route_match = None  # Set by the router
 

--- a/wptserve/server.py
+++ b/wptserve/server.py
@@ -230,7 +230,8 @@ class WebTestRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 return
 
             self.logger.debug("%s %s" % (request.method, request.request_path))
-            handler = self.server.router.get_handler(request)
+            match_parts, handler = self.server.router.get_handler(request.method, request.url_parts.path)
+            request.match_parts = match_parts
 
             # If the handler we used for the request had a non-default base path
             # set update the doc_root of the request to reflect this


### PR DESCRIPTION
In cases like .any.js files for wpt we create some virtual resources
for on-disk files. It would be nice if they appeared in directory
listings. To allow that to happen, we add a mechanism so that when a
handler is registered with the router we can also register a
corresponding listing_fixup function that takes the request and the
list of files in the directory and returns an amended list of files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/wptserve/115)
<!-- Reviewable:end -->
